### PR TITLE
Fall back to __builtin_clz when lzcnt isn't available (fixes #60)

### DIFF
--- a/inc/NativeJIT/BitOperations.h
+++ b/inc/NativeJIT/BitOperations.h
@@ -134,10 +134,15 @@ namespace NativeJIT
                    ? true
                    : false;
 #else
+    #ifdef __LZCNT__
             *highestBitSetIndex = __lzcnt64(value);
             bool retval = *highestBitSetIndex != 64;
             *highestBitSetIndex = 63 - *highestBitSetIndex;
             return retval;
+    #else
+            *highestBitSetIndex = 63 - __builtin_clzll(value);
+            return value != 0;
+    #endif
 #endif
         }
 


### PR DESCRIPTION
This fixes #60 (originally had a commit message of #50, so sorry for that confusion). It turns out gcc and clang both define __LZCNT__ only when it's supported (which is why the file __lzcnt64 is defined in forces lzcnt support when it's not already defined -- it assumes -march and -mlzcnt weren't set appropriately, so it implicitly enables -mlzcnt).

```
corbin@dev:~/tmp$ g++ -march=ivybridge test.cpp && ./a.out 
__LZCNT__ not defined
corbin@dev:~/tmp$ g++ -march=haswell test.cpp && ./a.out 
__LZCNT__ defined
corbin@dev:~/tmp$ clang++ -march=ivybridge test.cpp && ./a.out 
__LZCNT__ not defined
corbin@dev:~/tmp$ clang++ -march=haswell test.cpp && ./a.out 
__LZCNT__ defined
```

Anyway, this uses lzcnt when it's available, or falls back to __builtin_clz when it's not. As I mentioned in #60, I think bsr might actually be the best instruction for this,  but this should get the project at least building for people with older CPUs, and it will leave the code for people with Haswell alone. 

For reference, here's the code that would be [generated on Ivy Bridge](https://godbolt.org/g/wKA6Qo), and here's the [Haswell code](https://godbolt.org/g/rjIjG2). The bsr code is markedly simpler (though only because Clang handles this incredibly cleverly -- the gcc code for bsr is unfortunately bad and lzcnt is marginally better).