### PR TITLE
Fix 1-1-1-1 bug in parser.

### DIFF
--- a/Examples/Parser/Parser.cpp
+++ b/Examples/Parser/Parser.cpp
@@ -152,7 +152,6 @@ namespace Examples
     NativeJIT::Node<float>& Parser::ParseSum()
     {
         auto& left = ParseProduct();
-
         SkipWhite();
         if (PeekChar() == '+')
         {
@@ -164,9 +163,16 @@ namespace Examples
         else if (PeekChar() == '-')
         {
             GetChar();
-            auto& right = ParseSum();
+            auto& right = ParseProduct();
 
-            return m_expression.Sub(left, right);
+            auto& difference = m_expression.Sub(left, right);
+
+            if (PeekChar() == '+' || PeekChar() == '-') {
+                auto& rest = ParseSum();
+                return m_expression.Add(difference, rest);
+            } else {
+                return difference;
+            }
         }
         else
         {
@@ -501,6 +507,7 @@ bool Test()
 
         // Subtraction
         TestCase("4-5", -1.0),
+        TestCase("1-1-1-1", -2.0),
 
         // Multiplication
         TestCase("2*3", 6.0),


### PR DESCRIPTION
The test case "1-1-1-1" is evaluated as "1-(1-(1-1))". Maybe this
fix is not the most elegant, but it fixes this issue.