### PR TITLE
Fix 1-1-1-1 bug in parser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,6 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 # Project-wide settings for NativeJIT
 project(NativeJIT CXX C)
 
-###############################################################################
-
-# gtest
-
-add_subdirectory(googletest)
-
-include_directories(
-  ${gtest_SOURCE_DIR}/include
-)
-
-###############################################################################
-
-
 if (WIN32 OR CYGWIN)
     set(NATIVEJIT_PLATFORM_POSIX 0)
     set(NATIVEJIT_PLATFORM_WINDOWS 1)
@@ -49,7 +36,7 @@ set(GTEST_REQUIRED_FLAGS "-Wno-shift-sign-overflow -Wno-missing-noreturn -Wno-us
 set(WEVERYTHING_FLAGS "-Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic ${GTEST_REQUIRED_FLAGS}")
 
 if(MSVC)
-  set(COMMON_CXX_FLAGS "${COMMON_CXX_FLAGS} /W4 /WX")
+  set(COMMON_CXX_FLAGS "${COMMON_CXX_FLAGS} /W4 /WX -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
   set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG} ${COMMON_CXX_FLAGS} /MTd")
   set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} ${COMMON_CXX_FLAGS} /MT")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
@@ -60,6 +47,18 @@ else()
   # set(CMAKE_CXX_FLAGS "-msse4.2 -std=c++14 -Wall -Wextra -Werror -Wold-style-cast ${WEVERYTHING_FLAGS}")
   set(CMAKE_CXX_FLAGS "-march=native -std=c++14 -Wall -Wextra -Werror -Wold-style-cast")
 endif()
+
+###############################################################################
+
+# gtest
+
+add_subdirectory(googletest)
+
+include_directories(
+  ${gtest_SOURCE_DIR}/include
+)
+
+###############################################################################
 
 
 # This allows the solution to group projects into folders like src and test.

--- a/Configure_MSVC.bat
+++ b/Configure_MSVC.bat
@@ -24,5 +24,5 @@ setlocal
 
 mkdir build-msvc
 pushd build-msvc
-cmake -G "Visual Studio 14 2015 Win64" ..
+cmake -G "Visual Studio 15 2017 Win64" ..
 popd

--- a/Examples/Parser/Parser.cpp
+++ b/Examples/Parser/Parser.cpp
@@ -153,10 +153,10 @@ namespace Examples
     {
         auto* left = &ParseProduct();
 
-        SkipWhite();
-
         while (true)
         {
+            SkipWhite();
+
             char c = PeekChar();
             if (c == '+')
             {
@@ -174,7 +174,6 @@ namespace Examples
             {
                 break;
             }
-            SkipWhite();
         }
         return *left;
     }
@@ -182,19 +181,22 @@ namespace Examples
 
     NativeJIT::Node<float>& Parser::ParseProduct()
     {
-        auto& left = ParseTerm();
+        auto* left = &ParseTerm();
 
-        SkipWhite();
-        if (PeekChar() == '*')
+        while (true)
         {
-            GetChar();
-            auto& right = ParseProduct();
+            SkipWhite();
 
-            return m_expression.Mul(left, right);
-        }
-        else
-        {
-            return left;
+            if (PeekChar() == '*')
+            {
+                GetChar();
+                auto& right = ParseProduct();
+                return m_expression.Mul(*left, right);
+            }
+            else
+            {
+                return *left;
+            }
         }
     }
 
@@ -237,8 +239,10 @@ namespace Examples
             }
             else if (symbol.compare("sqrt") == 0)
             {
+                SkipWhite();
                 Consume('(');
                 auto& parameter = ParseSum();
+                SkipWhite();
                 Consume(')');
                 auto & sqrtFunction = m_expression.Immediate(sqrtf);
                 return m_expression.Call(sqrtFunction, parameter);

--- a/Examples/Parser/Parser.cpp
+++ b/Examples/Parser/Parser.cpp
@@ -151,27 +151,32 @@ namespace Examples
 
     NativeJIT::Node<float>& Parser::ParseSum()
     {
-        auto& left = ParseProduct();
+        auto* left = &ParseProduct();
 
         SkipWhite();
-        if (PeekChar() == '+')
-        {
-            GetChar();
-            auto& right = ParseSum();
 
-            return m_expression.Add(left, right);
-        }
-        else if (PeekChar() == '-')
+        while (true)
         {
-            GetChar();
-            auto& right = ParseSum();
-
-            return m_expression.Sub(left, right);
+            char c = PeekChar();
+            if (c == '+')
+            {
+                GetChar();
+                auto& right = ParseProduct();
+                left = &m_expression.Add(*left, right);
+            }
+            else if (c == '-')
+            {
+                GetChar();
+                auto& right = ParseProduct();
+                left = &m_expression.Sub(*left, right);
+            }
+            else
+            {
+                break;
+            }
+            SkipWhite();
         }
-        else
-        {
-            return left;
-        }
+        return *left;
     }
 
 
@@ -523,6 +528,10 @@ bool Test()
         TestCase("2*2+1", 5.0f),
         TestCase("1+1+1", 3.0f),
         TestCase("1 * 2 * 3", 6.0f),
+
+        // Left associativity
+        TestCase("1-1-1", -1.0f),
+        TestCase("1-2-3-4", -8.0f),
     };
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ branches:
     - master
     - staging_master
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 clone_depth: 1
 


### PR DESCRIPTION
As per PR #76, these commits correct the parsing example for sum and multiply to be left-associative, as discovered by PetterS.