### PR TITLE
Delete StlAllocator assignment operator instead of making it private

### DIFF
--- a/inc/Temporary/StlAllocator.h
+++ b/inc/Temporary/StlAllocator.h
@@ -92,7 +92,7 @@ namespace Allocators
 
         // StlAllocator does not implement an assignment operator because
         // it stores a reference to its IAllocator.
-        StlAllocator& operator=(const StlAllocator&);
+        StlAllocator& operator=(const StlAllocator&) = delete;
 
         IAllocator& m_allocator;
     };


### PR DESCRIPTION
resolves this compiler warning with clang 10:

```
../inc/Temporary/StlAllocator.h:95:23: error: definition of implicit copy constructor for 'StlAllocator<unsigned char>' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
        StlAllocator& operator=(const StlAllocator&);

```